### PR TITLE
feat: only support float

### DIFF
--- a/src/bench/bench.rs
+++ b/src/bench/bench.rs
@@ -63,7 +63,6 @@ fn make_baseline(emb: Vec<Vec<f64>>, flat_idx: &mut flat::flat::FlatIndex<f64>) 
     flat_idx.train();
 }
 
-#[cfg(test)]
 pub fn run_demo() {
     let (base, ns, ts) = make_normal_distribution_clustering(5, 1000, 1, 2, 100.0);
     let mut flat_idx = flat::flat::FlatIndex::<f64>::new();

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -13,7 +13,7 @@ where
 {
     return match m {
         Manhattan => manhattan_distance(vec1, vec2),
-        // Dot => dot(vec1, vec2),
+        Dot => dot(vec1, vec2),
         Euclidean => euclidean_distance(vec1, vec2),
         Default => Result::Err("unknown method"),
     };
@@ -61,7 +61,7 @@ where
         let diff = vec1[i] - vec2[i];
         res += diff * diff;
     }
-    return Result::Ok(res);
+    return Result::Ok(res.sqrt());
 }
 
 pub fn euclidean_distance_range<T>(
@@ -81,7 +81,7 @@ where
         let diff = vec1[i] - vec2[i];
         res += diff * diff;
     }
-    return Result::Ok(res);
+    return Result::Ok(res.sqrt());
 }
 
 pub fn get_norm<T>(vec1: &[T]) -> T

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -1,5 +1,4 @@
 extern crate num;
-use crate::common::node::Element;
 use crate::common::node::FloatElement;
 
 pub enum MetricType {
@@ -10,7 +9,7 @@ pub enum MetricType {
 
 pub fn metric<T>(vec1: &[T], vec2: &[T], m: MetricType) -> Result<T, &'static str>
 where
-    T: Element,
+    T: FloatElement,
 {
     return match m {
         Manhattan => manhattan_distance(vec1, vec2),
@@ -38,7 +37,7 @@ where
 
 pub fn manhattan_distance<T>(vec1: &[T], vec2: &[T]) -> Result<T, &'static str>
 where
-    T: Element,
+    T: FloatElement,
 {
     if vec1.len() != vec2.len() {
         return Result::Err("different dimensions");
@@ -52,7 +51,7 @@ where
 
 pub fn euclidean_distance<T>(vec1: &[T], vec2: &[T]) -> Result<T, &'static str>
 where
-    T: Element,
+    T: FloatElement,
 {
     if vec1.len() != vec2.len() {
         return Result::Err("different dimensions");
@@ -72,7 +71,7 @@ pub fn euclidean_distance_range<T>(
     end: usize,
 ) -> Result<T, &'static str>
 where
-    T: Element,
+    T: FloatElement,
 {
     if vec1.len() != vec2.len() {
         return Result::Err("different dimensions");

--- a/src/common/neighbor.rs
+++ b/src/common/neighbor.rs
@@ -2,12 +2,12 @@ extern crate num;
 use crate::common::node;
 use std::cmp::Ordering;
 #[derive(Default, Clone, PartialEq, Debug)]
-pub struct Neighbor<E: node::Element> {
+pub struct Neighbor<E: node::FloatElement> {
     pub _idx: usize,
     pub _distance: E,
 }
 
-impl<E: node::Element> Neighbor<E> {
+impl<E: node::FloatElement> Neighbor<E> {
     pub fn new(idx: usize, distance: E) -> Neighbor<E> {
         return Neighbor {
             _idx: idx,
@@ -24,16 +24,16 @@ impl<E: node::Element> Neighbor<E> {
     }
 }
 
-impl<E: node::Element> Ord for Neighbor<E> {
+impl<E: node::FloatElement> Ord for Neighbor<E> {
     fn cmp(&self, other: &Neighbor<E>) -> Ordering {
         self._distance.partial_cmp(&other._distance).unwrap()
     }
 }
 
-impl<E: node::Element> PartialOrd for Neighbor<E> {
+impl<E: node::FloatElement> PartialOrd for Neighbor<E> {
     fn partial_cmp(&self, other: &Neighbor<E>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<E: node::Element> Eq for Neighbor<E> {}
+impl<E: node::FloatElement> Eq for Neighbor<E> {}

--- a/src/common/node.rs
+++ b/src/common/node.rs
@@ -2,7 +2,7 @@ use crate::common::metrics::manhattan_distance;
 use crate::common::metrics;
 use num::traits::{FromPrimitive, NumAssign};
 
-pub trait Element:
+trait Element:
     FromPrimitive
     + Sized
     + Default
@@ -50,21 +50,17 @@ macro_rules! to_float_element {
 
 to_element!(f64);
 to_element!(f32);
-to_element!(i64);
-to_element!(i32);
-to_element!(i8);
-to_element!(i16);
 to_float_element!(f64);
 to_float_element!(f32);
 
 #[derive(Clone, Debug, Default)]
-pub struct Node<E: Element> {
+pub struct Node<E: FloatElement> {
     vectors: Vec<E>,
     dimensions: usize,
     id: Option<usize>,
 }
 
-impl<E: Element> Node<E> {
+impl<E: FloatElement> Node<E> {
     pub fn new(vectors: &[E]) -> Node<E> {
         Node {
             vectors: vectors.to_vec(),
@@ -127,13 +123,6 @@ fn node_test() {
     // f64
     let v = vec![0.1, 0.2];
     let v2 = vec![0.2, 0.1];
-    let n = Node::new(&v);
-    let n2 = Node::new(&v2);
-    n.distance(&n2, manhattan_distance).unwrap();
-
-    // int
-    let v = vec![1, 1];
-    let v2 = vec![2, 1];
     let n = Node::new(&v);
     let n2 = Node::new(&v2);
     n.distance(&n2, manhattan_distance).unwrap();

--- a/src/fastann.rs
+++ b/src/fastann.rs
@@ -1,6 +1,6 @@
 use crate::common::node;
 use crate::common::metrics;
-trait AnnIndex<E: node::Element> {
+trait AnnIndex<E: node::FloatElement> {
     fn construct(&self); // construct algorithm structure
     fn add(&mut self, item: &node::Node<E>);
     fn once_constructed(&self) -> bool; // has already been constructed?


### PR DESCRIPTION
Once I wanna support both int and float type, and then I found that there is even any situation that you hope your index is int, the index is naturally float.
in the future, if we want int type for memory optimization, we can revert this commit.